### PR TITLE
Minor signedness and type comparison changes

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -96,7 +96,7 @@ void simulationContainer::update()
 	    std::unordered_map<int, std::future<bool>> tasks;
 		
 
-	    for (int i = 0; i < quads.size(); ++i)
+	    for (size_t i = 0; i < quads.size(); ++i)
 	    {
 	        // Skip empty quadrants
 	        if (quads[i]->particles.size() == 0)

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -275,8 +275,8 @@ void simulationContainer::worker(quadTree* q)
 
             double radiiSum = radiusA + b->getRadius();
 
-            if (abs(positionA.x - positionB.x) >= radiiSum ||
-                abs(positionA.y - positionB.y) >= radiiSum) // Skip collision detection if particles are not close enough
+            if (std::abs(positionA.x - positionB.x) >= radiiSum ||
+                std::abs(positionA.y - positionB.y) >= radiiSum) // Skip collision detection if particles are not close enough
                 continue;
 
             double distanceSquared = positionA.distanceSquared(positionB);

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -42,7 +42,7 @@ void grid::render(aCamera *camera)
         } else
         {
             int currentImportanceLevel = 0;
-            for (int level = 0; level < importanceIntervals.size(); ++level)
+            for (size_t level = 0; level < importanceIntervals.size(); ++level)
             {
                 if (i % importanceIntervals[level] == 0)
                 {
@@ -73,7 +73,7 @@ void grid::render(aCamera *camera)
         } else
         {
             int currentImportanceLevel = 0;
-            for (int level = 0; level < importanceIntervals.size(); ++level)
+            for (size_t level = 0; level < importanceIntervals.size(); ++level)
             {
                 if (i % importanceIntervals[level] == 0)
                 {


### PR DESCRIPTION
Minor linting fixes:
* `std::vector<>`'s size is unsigned, so `size_t` rather than `int`
* legacy c `abs()` is for ints, requiring implicit conversion
